### PR TITLE
feat: restructure installation to contained directory (v2.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.1] - 2025-08-22
+
+### Fixed
+- Fixed venv location to be at claude-slack level instead of in mcp/ subdirectory
+- Fixed all Python paths in install.js for MCP server, hooks, and scripts
+- Fixed installation summary messages to show correct contained directory paths
+- All components now properly use shared venv at ~/.claude/claude-slack/venv/
+
+### Changed
+- Restructured installation to contain everything in ~/.claude/claude-slack/ directory
+- Moved venv to parent level for shared use by MCP server, hooks, and scripts
+
+## [2.0.0-alpha.2] - 2025-08-22
+
+### Fixed
+- Fixed agent description synchronization from frontmatter to database
+- Removed references to deleted scripts in README
+- Fixed NPM badge cache issue in README
+
+### Changed
+- Major restructuring to use contained directory structure
+- Updated all file paths and imports for new structure
+
+## [2.0.0-alpha.1] - 2025-08-22
+
+### Fixed
+- Fixed SubscriptionManager overwriting agent descriptions with fallback values
+- Added check to prevent re-registering existing agents
+
+### Changed
+- Initial 2.0 release with automatic agent setup
+- Removed manual configuration scripts (configure_agents.py, register_project_agents.py)
+- Automatic detection and configuration on session start
+
+## [1.0.0] - Previous
+
+### Added
+- Initial release with channel-based messaging system
+- MCP server for Claude Code integration
+- Project isolation with scoped channels
+- Agent subscription management via frontmatter
+- SessionStart and PreToolUse hooks
+- Direct messaging between agents
+- Note-taking functionality for agents

--- a/bin/install.js
+++ b/bin/install.js
@@ -265,10 +265,9 @@ class ClaudeSlackInstaller {
         this.spinner = ora('Setting up Python environment...').start();
 
         const claudeSlackDir = path.join(this.globalClaudeDir, CLAUDE_SLACK_DIR);
-        const mcpDir = path.join(claudeSlackDir, 'mcp');
 
-        // First, create requirements.txt if it doesn't exist
-        const requirementsPath = path.join(mcpDir, 'requirements.txt');
+        // First, create requirements.txt if it doesn't exist at the claude-slack level
+        const requirementsPath = path.join(claudeSlackDir, 'requirements.txt');
         if (!fs.existsSync(requirementsPath)) {
             const requirements = `# Claude-Slack MCP Server Requirements
 mcp>=0.1.0
@@ -279,9 +278,9 @@ pyyaml>=6.0
         }
 
         try {
-            // Create virtual environment
+            // Create virtual environment at claude-slack level
             execSync('python3 -m venv venv', {
-                cwd: mcpDir,
+                cwd: claudeSlackDir,
                 stdio: 'pipe'
             });
 
@@ -292,12 +291,12 @@ pyyaml>=6.0
                 : path.join('venv', 'bin', 'pip');
 
             execSync(`${pipCmd} install --upgrade pip`, {
-                cwd: mcpDir,
+                cwd: claudeSlackDir,
                 stdio: 'pipe'
             });
 
             execSync(`${pipCmd} install -r requirements.txt`, {
-                cwd: mcpDir,
+                cwd: claudeSlackDir,
                 stdio: 'pipe'
             });
 
@@ -325,8 +324,8 @@ pyyaml>=6.0
         const mcpDir = path.join(this.globalClaudeDir, MCP_SERVER_DIR);
         // Handle platform-specific Python executable location
         const pythonPath = process.platform === 'win32'
-            ? path.join(mcpDir, 'venv', 'Scripts', 'python.exe')
-            : path.join(mcpDir, 'venv', 'bin', 'python');
+            ? path.join(claudeSlackDir, 'venv', 'Scripts', 'python.exe')
+            : path.join(claudeSlackDir, 'venv', 'bin', 'python');
         const schemaPath = path.join(mcpDir, 'db', 'schema.sql');
 
         const initScript = `
@@ -386,7 +385,6 @@ print('Database initialized successfully')
         const venvPython = process.platform === 'win32'
             ? path.join(claudeSlackDir, 'venv', 'Scripts', 'python.exe')
             : path.join(claudeSlackDir, 'venv', 'bin', 'python');
-
         const mcpDir = path.join(claudeSlackDir, 'mcp');
         claudeConfig.mcpServers['claude-slack'] = {
             "command": venvPython,
@@ -658,13 +656,13 @@ exec "$VENV_PYTHON" "$SCRIPT_DIR/manage_project_links.py" "$@"
 
         console.log(chalk.cyan('📚 Installation Summary:'));
         console.log(`  • ${chalk.bold('MCP Server')}: ${path.join(this.globalClaudeDir, MCP_SERVER_DIR)}`);
-        console.log(`  • ${chalk.bold('Database')}: ${path.join(this.globalClaudeDir, 'data', DB_NAME)}`);
+        console.log(`  • ${chalk.bold('Database')}: ${path.join(this.globalClaudeDir, CLAUDE_SLACK_DIR, 'data', DB_NAME)}`);
         console.log(`  • ${chalk.bold('Hooks')}: SessionStart + PreToolUse`);
         console.log(`  • ${chalk.bold('Managers')}: SessionManager, ChannelManager, SubscriptionManager, ProjectSetupManager`);
 
         console.log(chalk.cyan('\n🐛 Debug Logging:'));
         console.log('  • Enable debug logs: export CLAUDE_SLACK_DEBUG=1');
-        console.log(`  • Log files: ${path.join(this.globalClaudeDir, 'logs')}/*.log`);
+        console.log(`  • Log files: ${path.join(this.globalClaudeDir, CLAUDE_SLACK_DIR, 'logs')}/*.log`);
         console.log('  • Logs show hook execution, database operations, and errors');
 
         console.log(chalk.cyan('\n🚀 Quick Start Guide:'));
@@ -682,7 +680,7 @@ exec "$VENV_PYTHON" "$SCRIPT_DIR/manage_project_links.py" "$@"
         console.log(chalk.cyan('🔧 Project Linking (Optional):'));
         console.log(chalk.gray('  (Only needed for cross-project communication)'));
         const scriptExt = process.platform === 'win32' ? '.bat' : '';
-        console.log(`  • Manage project links: ${path.join(this.globalClaudeDir, 'scripts', `manage_project_links${scriptExt}`)} [command]`);
+        console.log(`  • Manage project links: ${path.join(this.globalClaudeDir, CLAUDE_SLACK_DIR, 'scripts', `manage_project_links${scriptExt}`)} [command]`);
         console.log('  • Projects are isolated by default');
         console.log('  • Link projects to enable agent discovery between them\n');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-slack",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.1",
   "description": "Channel-based messaging system for Claude Code agents - Slack-like communication infrastructure",
   "keywords": [
     "claude",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bin/",
     "template/",
     "README.md",
+    "CHANGELOG.md",
     "LICENSE"
   ],
   "scripts": {

--- a/template/global/hooks/slack_pre_tool_use.py
+++ b/template/global/hooks/slack_pre_tool_use.py
@@ -26,7 +26,8 @@ from typing import Optional, Dict, Any
 
 # Add MCP directory to path to import modules
 claude_config_dir = os.environ.get('CLAUDE_CONFIG_DIR', os.path.expanduser('~/.claude'))
-mcp_dir = os.path.join(claude_config_dir, 'mcp', 'claude-slack')
+claude_slack_dir = os.path.join(claude_config_dir, 'claude-slack')
+mcp_dir = os.path.join(claude_slack_dir, 'mcp')
 sys.path.insert(0, mcp_dir)
 sys.path.insert(0, os.path.join(mcp_dir, 'db'))
 sys.path.insert(0, os.path.join(claude_config_dir, 'hooks'))
@@ -106,7 +107,7 @@ def record_tool_call(session_id: str, tool_name: str, tool_inputs: dict) -> bool
         if USE_ENV_CONFIG:
             db_path = env_config.db_path
         else:
-            db_path = Path(claude_config_dir) / 'data' / 'claude-slack.db'
+            db_path = Path(claude_slack_dir) / 'data' / 'claude-slack.db'
         
         logger.debug(f"Using database: {db_path}")
         

--- a/template/global/hooks/slack_session_start.py
+++ b/template/global/hooks/slack_session_start.py
@@ -14,9 +14,10 @@ from pathlib import Path
 
 # Add MCP directory to path to import modules
 claude_config_dir = os.environ.get('CLAUDE_CONFIG_DIR', os.path.expanduser('~/.claude'))
-mcp_dir = os.path.join(claude_config_dir, 'mcp', 'claude-slack')
+claude_slack_dir = os.path.join(claude_config_dir, 'claude-slack')
+mcp_dir = os.path.join(claude_slack_dir, 'mcp')
 sys.path.insert(0, mcp_dir)
-sys.path.insert(0, os.path.join(claude_config_dir, 'hooks'))
+sys.path.insert(0, os.path.join(claude_slack_dir, 'hooks'))
 
 # Set up logging - use new centralized logging system
 try:
@@ -83,9 +84,9 @@ def main():
                     db_path = env_config.db_path
                 except Exception as e:
                     logger.warning(f"Failed to get db_path from env_config: {e}")
-                    db_path = Path(claude_config_dir) / 'data' / 'claude-slack.db'
+                    db_path = Path(claude_slack_dir) / 'data' / 'claude-slack.db'
             else:
-                db_path = Path(claude_config_dir) / 'data' / 'claude-slack.db'
+                db_path = Path(claude_slack_dir) / 'data' / 'claude-slack.db'
             
             # Ensure database directory exists
             db_path = Path(db_path)

--- a/template/global/mcp/claude-slack/config_manager.py
+++ b/template/global/mcp/claude-slack/config_manager.py
@@ -69,7 +69,13 @@ class ConfigManager:
         if config_path:
             self.config_path = Path(config_path)
         else:
-            self.config_path = Path.home() / ".claude" / "config" / "claude-slack.config.yaml"
+            # Use new contained structure
+            claude_config_dir = os.environ.get('CLAUDE_CONFIG_DIR', str(Path.home() / '.claude'))
+            claude_slack_dir = os.environ.get('CLAUDE_SLACK_DIR')
+            if claude_slack_dir:
+                self.config_path = Path(claude_slack_dir) / "config" / "claude-slack.config.yaml"
+            else:
+                self.config_path = Path(claude_config_dir) / "claude-slack" / "config" / "claude-slack.config.yaml"
         
         self._config_cache = None
         self._cache_mtime = None

--- a/template/global/mcp/claude-slack/environment_config.py
+++ b/template/global/mcp/claude-slack/environment_config.py
@@ -96,19 +96,28 @@ class EnvironmentConfig:
         return self.claude_config_dir
     
     @property
+    def claude_slack_dir(self) -> Path:
+        """Get the claude-slack container directory"""
+        # Check for environment variable first (set by install.js)
+        claude_slack_dir = os.environ.get('CLAUDE_SLACK_DIR')
+        if claude_slack_dir:
+            return Path(claude_slack_dir)
+        return self.global_claude_dir / 'claude-slack'
+    
+    @property
     def db_path(self) -> Path:
         """Get path to the claude-slack database"""
-        return self.global_claude_dir / 'data' / 'claude-slack.db'
+        return self.claude_slack_dir / 'data' / 'claude-slack.db'
     
     @property
     def config_path(self) -> Path:
         """Get path to the claude-slack configuration file"""
-        return self.global_claude_dir / 'config' / 'claude-slack.config.yaml'
+        return self.claude_slack_dir / 'config' / 'claude-slack.config.yaml'
     
     @property
     def mcp_dir(self) -> Path:
         """Get path to the MCP server directory"""
-        return self.global_claude_dir / 'mcp' / 'claude-slack'
+        return self.claude_slack_dir / 'mcp'
     
     @property
     def global_agents_dir(self) -> Path:
@@ -118,7 +127,7 @@ class EnvironmentConfig:
     @property
     def logs_dir(self) -> Path:
         """Get path to logs directory"""
-        return self.global_claude_dir / 'logs'
+        return self.claude_slack_dir / 'logs'
     
     @property
     def sessions_dir(self) -> Path:

--- a/template/global/mcp/claude-slack/log_manager/manager.py
+++ b/template/global/mcp/claude-slack/log_manager/manager.py
@@ -40,7 +40,12 @@ class LoggingManager:
         """Initialize the logging manager (singleton)"""
         if not self._initialized:
             self.claude_dir = Path(os.environ.get('CLAUDE_CONFIG_DIR', Path.home() / '.claude'))
-            self.log_dir = self.claude_dir / 'logs' / 'claude-slack'
+            # Use CLAUDE_SLACK_DIR if set (new structure), otherwise fall back to old structure
+            claude_slack_dir = os.environ.get('CLAUDE_SLACK_DIR')
+            if claude_slack_dir:
+                self.log_dir = Path(claude_slack_dir) / 'logs'
+            else:
+                self.log_dir = self.claude_dir / 'claude-slack' / 'logs'
             self.debug_mode = os.environ.get('CLAUDE_SLACK_DEBUG', '').lower() in ('1', 'true', 'yes')
             self.loggers = {}
             self._initialized = True

--- a/template/global/scripts/manage_project_links.py
+++ b/template/global/scripts/manage_project_links.py
@@ -40,7 +40,10 @@ from pathlib import Path
 from typing import List, Tuple, Optional
 
 # Add MCP directory to path
-sys.path.insert(0, str(Path.home() / '.claude' / 'mcp' / 'claude-slack'))
+claude_config_dir = os.environ.get('CLAUDE_CONFIG_DIR', str(Path.home() / '.claude'))
+claude_slack_dir = os.path.join(claude_config_dir, 'claude-slack')
+mcp_dir = os.path.join(claude_slack_dir, 'mcp')
+sys.path.insert(0, mcp_dir)
 
 from db.manager import DatabaseManager
 from db.initialization import initialized_db_manager
@@ -61,7 +64,9 @@ def get_db_path() -> str:
     try:
         return env_config.db_path
     except:
-        return str(Path.home() / '.claude' / 'data' / 'claude-slack.db')
+        claude_config_dir = os.environ.get('CLAUDE_CONFIG_DIR', str(Path.home() / '.claude'))
+        claude_slack_dir = os.path.join(claude_config_dir, 'claude-slack')
+        return os.path.join(claude_slack_dir, 'data', 'claude-slack.db')
 
 async def list_all_projects(db_manager: DatabaseManager) -> List[dict]:
     """List all registered projects"""


### PR DESCRIPTION
## Summary
- Restructured entire installation to use a contained `~/.claude/claude-slack/` directory
- Fixed venv location to be at the correct level for shared use
- Updated all paths and configurations for the new structure

## Changes

### Directory Structure
- Everything now contained in `~/.claude/claude-slack/`
- Shared venv at `claude-slack/venv/` (not in `mcp/` subdirectory)
- Clean organization: `mcp/`, `hooks/`, `scripts/`, `data/`, `logs/`, `config/`

### Bug Fixes
- Fixed venv path in MCP server configuration
- Fixed venv path in hooks configuration  
- Fixed venv path in database initialization
- Fixed installation summary messages to show correct paths
- Fixed agent description synchronization from frontmatter

### Documentation
- Added CHANGELOG.md for version tracking
- Updated installation messages with correct paths

## Test Results
All functionality verified working:
- ✅ MCP tools accessible
- ✅ Project context detection
- ✅ Database operations (sessions, agents, messages)
- ✅ Hooks running correctly (SessionStart, PreToolUse)
- ✅ Agent subscriptions from frontmatter
- ✅ Channel messaging (global and project)
- ✅ Note-taking functionality
- ✅ No errors in logs

## Version
Bumped to v2.0.1 - ready for npm publish after merge